### PR TITLE
Fix sound manager pausing

### DIFF
--- a/source/ps/Globals.cpp
+++ b/source/ps/Globals.cpp
@@ -19,6 +19,7 @@
 #include "Globals.h"
 
 #include "lib/external_libraries/libsdl.h"
+#include "soundmanager/SoundManager.h"
 
 
 bool g_app_minimized = false;
@@ -68,9 +69,15 @@ InReaction GlobalsInputHandler(const SDL_Event_* ev)
 #else
 	case SDL_ACTIVEEVENT:
 		if(ev->ev.active.state & SDL_APPACTIVE)
+		{
 			g_app_minimized = (ev->ev.active.gain == 0);	// negated
+			g_SoundManager->Pause( g_app_minimized );
+		}
 		if(ev->ev.active.state & SDL_APPINPUTFOCUS)
+		{
 			g_app_has_focus = (ev->ev.active.gain != 0);
+			g_SoundManager->Pause( !g_app_has_focus );
+		}
 		if(ev->ev.active.state & SDL_APPMOUSEFOCUS)
 			g_mouse_active = (ev->ev.active.gain != 0);
 		return IN_PASS;

--- a/source/scripting/ScriptGlue.cpp
+++ b/source/scripting/ScriptGlue.cpp
@@ -53,6 +53,7 @@
 #include "renderer/Renderer.h"
 #include "scriptinterface/ScriptInterface.h"
 #include "simulation2/Simulation2.h"
+#include "soundmanager/SoundManager.h"
 
 // rationale: the function table is now at the end of the source file to
 // avoid the need for forward declarations for every function.
@@ -340,6 +341,7 @@ JSBool SetPaused(JSContext* cx, uintN argc, jsval* vp)
 	try
 	{
 		g_Game->m_Paused = ToPrimitive<bool> (JS_ARGV(cx, vp)[0]);
+		g_SoundManager->Pause(g_Game->m_Paused);
 	}
 	catch (PSERROR_Scripting_ConversionFailed)
 	{

--- a/source/soundmanager/SoundManager.cpp
+++ b/source/soundmanager/SoundManager.cpp
@@ -269,6 +269,10 @@ CSoundManager::CSoundManager()
 	m_BufferCount		= 50;
 	m_BufferSize		= 65536;
 	m_MusicEnabled		= true;
+	m_MusicPaused 		= false;
+	m_AmbientPaused 	= false;
+	m_ActionPaused 		= false;
+
 	m_Enabled			= AlcInit() == INFO::OK;
 	InitListener();
 
@@ -445,6 +449,37 @@ void CSoundManager::PlayGroupItem(ISoundItem* anItem, ALfloat groupGain)
 		}
 	}
 }
+
+void CSoundManager::Pause(bool pauseIt)
+{
+	PauseMusic(pauseIt);
+	PauseAmbient(pauseIt);
+	PauseAction(pauseIt);
+}
+void CSoundManager::PauseMusic (bool pauseIt)
+{
+	if (m_CurrentTune && pauseIt)
+		m_CurrentTune->Pause();
+	else if ( m_CurrentTune )
+		m_CurrentTune->Resume();
+
+	m_MusicPaused = pauseIt;
+}
+void CSoundManager::PauseAmbient (bool pauseIt)
+{
+	if (m_CurrentEnvirons && pauseIt)
+		m_CurrentEnvirons->Pause();
+	else if ( m_CurrentEnvirons )
+		m_CurrentEnvirons->Resume();
+
+	m_AmbientPaused = pauseIt;
+}
+void CSoundManager::PauseAction (bool pauseIt)
+{
+	m_ActionPaused = pauseIt;
+}
+
+
 
 void CSoundManager::SetMusicEnabled (bool isEnabled)
 {

--- a/source/soundmanager/SoundManager.h
+++ b/source/soundmanager/SoundManager.h
@@ -54,6 +54,10 @@ protected:
 	bool m_MusicEnabled;
 	bool m_SoundEnabled;
 
+	bool m_MusicPaused;
+	bool m_AmbientPaused;
+	bool m_ActionPaused;
+
 public:
 	CSoundManager();
 	virtual ~CSoundManager();
@@ -91,7 +95,12 @@ public:
 	void SetMusicGain(float gain);
 	void SetAmbientGain(float gain);
 	void SetActionGain(float gain);
-	
+
+	void Pause(bool pauseIt);
+	void PauseMusic (bool pauseIt);
+	void PauseAmbient (bool pauseIt);
+	void PauseAction (bool pauseIt);
+
 protected:
 	void InitListener();
 	virtual Status AlcInit();

--- a/source/soundmanager/items/CSoundBase.cpp
+++ b/source/soundmanager/items/CSoundBase.cpp
@@ -249,6 +249,22 @@ void CSoundBase::StopAndDelete()
 	Stop();
 }
 
+void CSoundBase::Pause()
+{
+	if (m_ALSource != 0)
+	{
+		alSourcePause(m_ALSource);
+		AL_CHECK
+	}
+}
+void CSoundBase::Resume()
+{
+	if (m_ALSource != 0)
+	{
+		alSourcePlay(m_ALSource);
+		AL_CHECK
+	}
+}
 void CSoundBase::PlayLoop()
 {
 	if (m_ALSource != 0)

--- a/source/soundmanager/items/CSoundBase.h
+++ b/source/soundmanager/items/CSoundBase.h
@@ -69,6 +69,9 @@ public:
 	void PlayAsMusic();
 	void PlayAsAmbient();
 
+	void Pause();
+	void Resume();
+
 	CStrW* GetName();
 
 	virtual bool GetLooping();

--- a/source/soundmanager/items/ISoundItem.h
+++ b/source/soundmanager/items/ISoundItem.h
@@ -45,6 +45,8 @@ public:
 	virtual void EnsurePlay() = 0;
 	virtual void PlayAsMusic() = 0;
 	virtual void PlayAsAmbient() = 0;
+	virtual void Pause() = 0;
+	virtual void Resume() = 0;
 
 	virtual void PlayAndDelete() = 0;
 	virtual void StopAndDelete() = 0;


### PR DESCRIPTION
Music and ambient sounds will now pause when the game is paused either
through the in game pausing or when the window is sent to the
background.

Sending this now but don't expect it to be addressed until after the next release.
