### PR TITLE
Water Shader Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Excluded to make the git repo smaller (those are present in SVN)
-binaries/system/ActorEditor.exe
-binaries/system/AtlasUI.dll
-binaries/system/Collada.dll
-binaries/system/pyrogenesis.exe
-binaries/system/pyrogenesis.pdb
+binaries/system/*.exe
+binaries/system/*.dll
+binaries/system/*.pdb
+binaries/system/*.lib
+binaries/system/*.exp
+binaries/system/*.ilk
 
 # Build files
 *.so
@@ -21,6 +22,7 @@ build/workspaces/codeblocks/
 build/workspaces/gcc/
 build/workspaces/xcode3/
 build/workspaces/xcode4/
+build/workspaces/vc2013/
 build/premake/premake4/bin/release/premake4
 build/premake/premake4/build/gmake.macosx/obj/
 build/premake/premake4/build/gmake.unix/obj/
@@ -46,6 +48,7 @@ libraries/source/spidermonkey/include-unix-debug/
 libraries/source/spidermonkey/include-unix-release/
 libraries/source/spidermonkey/mozjs31/
 libraries/source/nvtt/src/build/
+libraries/*/wxwidgets/
 
 # Build files (libs) (OS X)
 libraries/osx/boost/

--- a/binaries/data/mods/public/shaders/glsl/dof.fs
+++ b/binaries/data/mods/public/shaders/glsl/dof.fs
@@ -26,7 +26,7 @@ float linearizeDepth(float depth)
 }
 
 
-void main(void)
+void main()
 {
 	vec3 color = texture2D(renderedTex, v_tex).rgb;
 

--- a/libraries/source/spidermonkey/include-win32-release/mozilla/Char16.h
+++ b/libraries/source/spidermonkey/include-win32-release/mozilla/Char16.h
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* Implements a UTF-16 character type. */
+#include <stdint.h>
 
 #ifndef mozilla_Char16_h
 #define mozilla_Char16_h
@@ -32,8 +33,8 @@
     */
 #  define MOZ_UTF16_HELPER(s) L##s
 #  define _CHAR16T
-   typedef wchar_t char16_t;
-   typedef unsigned int char32_t;
+typedef wchar_t char16_t;
+typedef unsigned int char32_t;
 #else
    /* C++11 has a builtin char16_t type. */
 #  define MOZ_UTF16_HELPER(s) u##s

--- a/source/renderer/Renderer.cpp
+++ b/source/renderer/Renderer.cpp
@@ -1119,8 +1119,8 @@ void CRenderer::ComputeReflectionCamera(CCamera& camera, const CBoundingBoxAlign
 	camera.ClipFrustum(CVector4D(0, 1, 0, -wm.m_WaterHeight));
 
 	SViewPort vp;
-	vp.m_Height = wm.m_ReflectionTextureSize;
-	vp.m_Width = wm.m_ReflectionTextureSize;
+	vp.m_Height = wm.m_RefTextureSize;
+	vp.m_Width = wm.m_RefTextureSize;
 	vp.m_X = 0;
 	vp.m_Y = 0;
 	camera.SetViewPort(vp);
@@ -1155,8 +1155,8 @@ void CRenderer::ComputeRefractionCamera(CCamera& camera, const CBoundingBoxAlign
 	camera.ClipFrustum(CVector4D(0, -1, 0, wm.m_WaterHeight + 0.5f));	// add some to avoid artifacts near steep shores.
 
 	SViewPort vp;
-	vp.m_Height = wm.m_RefractionTextureSize;
-	vp.m_Width = wm.m_RefractionTextureSize;
+	vp.m_Height = wm.m_RefTextureSize;
+	vp.m_Width = wm.m_RefTextureSize;
 	vp.m_X = 0;
 	vp.m_Y = 0;
 	camera.SetViewPort(vp);
@@ -1188,8 +1188,8 @@ void CRenderer::RenderReflections(const CShaderDefines& context, const CBounding
 	// Save the model-view-projection matrix so the shaders can use it for projective texturing
 	wm.m_ReflectionMatrix = m_ViewCamera.GetViewProjection();
 
-	float vpHeight = wm.m_ReflectionTextureSize;
-	float vpWidth = wm.m_ReflectionTextureSize;
+	float vpHeight = wm.m_RefTextureSize;
+	float vpWidth = wm.m_RefTextureSize;
 
 	SScreenRect screenScissor;
 	screenScissor.x1 = (GLint)floor((scissor[0].X*0.5f+0.5f)*vpWidth);
@@ -1271,8 +1271,8 @@ void CRenderer::RenderRefractions(const CShaderDefines& context, const CBounding
 	// Save the model-view-projection matrix so the shaders can use it for projective texturing
 	wm.m_RefractionMatrix = m_ViewCamera.GetViewProjection();
 
-	float vpHeight = wm.m_RefractionTextureSize;
-	float vpWidth = wm.m_RefractionTextureSize;
+	float vpHeight = wm.m_RefTextureSize;
+	float vpWidth = wm.m_RefTextureSize;
 
 	SScreenRect screenScissor;
 	screenScissor.x1 = (GLint)floor((scissor[0].X*0.5f+0.5f)*vpWidth);

--- a/source/renderer/WaterManager.cpp
+++ b/source/renderer/WaterManager.cpp
@@ -91,8 +91,7 @@ WaterManager::WaterManager()
 	
 	m_ReflectionTexture = 0;
 	m_RefractionTexture = 0;
-	m_ReflectionTextureSize = 0;
-	m_RefractionTextureSize = 0;
+	m_RefTextureSize = 0;
 	
 	m_ReflectionFbo = 0;
 	m_RefractionFbo = 0;
@@ -236,18 +235,10 @@ int WaterManager::LoadWaterTextures()
 		m_FoamTex = texture;
 	}
 	
-	m_ReflectionTextureSize = g_Renderer.GetHeight() * 0.66;	// Higher settings give a better result
-	m_RefractionTextureSize = g_Renderer.GetHeight() * 0.33;	// Lower settings actually sorta look better since it blurs.
+	// Use screen-sized textures for minimum artifacts.
+	m_RefTextureSize = g_Renderer.GetHeight();
 	
-	if (round_down_to_pow2(m_ReflectionTextureSize)/m_ReflectionTextureSize < 0.65)
-		m_ReflectionTextureSize = round_up_to_pow2(m_ReflectionTextureSize);
-	else
-		m_ReflectionTextureSize = round_down_to_pow2(m_ReflectionTextureSize);
-	
-	if (round_down_to_pow2(m_RefractionTextureSize)/m_RefractionTextureSize < 0.7)
-		m_RefractionTextureSize = round_up_to_pow2(m_RefractionTextureSize);
-	else
-		m_RefractionTextureSize = round_down_to_pow2(m_RefractionTextureSize);
+	m_RefTextureSize = round_up_to_pow2(m_RefTextureSize);
 	
 	// Create reflection texture
 	glGenTextures(1, &m_ReflectionTexture);
@@ -256,7 +247,7 @@ int WaterManager::LoadWaterTextures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA8, (GLsizei)m_ReflectionTextureSize, (GLsizei)m_ReflectionTextureSize, 0,  GL_RGBA, GL_UNSIGNED_BYTE, 0);
+	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA8, (GLsizei)m_RefTextureSize, (GLsizei)m_RefTextureSize, 0,  GL_RGBA, GL_UNSIGNED_BYTE, 0);
 	
 	// Create refraction texture
 	glGenTextures(1, &m_RefractionTexture);
@@ -265,7 +256,7 @@ int WaterManager::LoadWaterTextures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGB8, (GLsizei)m_RefractionTextureSize, (GLsizei)m_RefractionTextureSize, 0,  GL_RGB, GL_UNSIGNED_BYTE, 0);
+	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGB8, (GLsizei)m_RefTextureSize, (GLsizei)m_RefTextureSize, 0,  GL_RGB, GL_UNSIGNED_BYTE, 0);
 
 	// Create depth textures
 	glGenTextures(1, &m_ReflFboDepthTexture);
@@ -274,7 +265,7 @@ int WaterManager::LoadWaterTextures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, (GLsizei)m_ReflectionTextureSize, (GLsizei)m_ReflectionTextureSize, 0,  GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, NULL);
+	glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, (GLsizei)m_RefTextureSize, (GLsizei)m_RefTextureSize, 0,  GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, NULL);
 	
 	glGenTextures(1, &m_RefrFboDepthTexture);
 	glBindTexture(GL_TEXTURE_2D, m_RefrFboDepthTexture);
@@ -282,7 +273,7 @@ int WaterManager::LoadWaterTextures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, (GLsizei)m_RefractionTextureSize, (GLsizei)m_RefractionTextureSize, 0,  GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, NULL);
+	glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32, (GLsizei)m_RefTextureSize, (GLsizei)m_RefTextureSize, 0,  GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, NULL);
 
 	// Create the Fancy Effects texture
 	glGenTextures(1, &m_FancyTextureNormal);

--- a/source/renderer/WaterManager.h
+++ b/source/renderer/WaterManager.h
@@ -103,8 +103,7 @@ public:
 	// Reflection and refraction textures for fancy water
 	GLuint m_ReflectionTexture;
 	GLuint m_RefractionTexture;
-	size_t m_ReflectionTextureSize;
-	size_t m_RefractionTextureSize;
+	size_t m_RefTextureSize;
 
 	// framebuffer objects
 	GLuint m_RefractionFbo;


### PR DESCRIPTION
-Reduces distortion of reflections and refractions.
-Adjusts the fresnel term to make reflections fall off more naturally.
-Fixes specular reflections for water.
-Increases the reflection and refraction texture sizes to screen size.

-Cleaned up a few things in WaterManager and Renderer.
-Cleaned up a bunch of things in the water shader.
-Tiny cleanup in the dof shader

# Housekeeping stuff
-Adjusted gitignore to account for visual studio.
-Added wxwidgets to gitignore.

-Added an include to one of the library source files to fix a compile issue. (in C11 you have to include stdint to get standard int types)