### PR TITLE
Fix compilation Atlas (wxWidget errors)

### DIFF
--- a/source/tools/atlas/AtlasObject/AtlasObjectImpl.cpp
+++ b/source/tools/atlas/AtlasObject/AtlasObjectImpl.cpp
@@ -164,7 +164,7 @@ void AtObj::add(const char* key, AtObj& data)
 
 void AtObj::add(const char* key, const wxString& value)
 {
-	add(key, value.wc_str());
+	add(key, static_cast<const wchar_t*>(value.wc_str()));
 }
 
 void AtObj::add(const char* key, const wchar_t* value)
@@ -187,7 +187,7 @@ void AtObj::set(const char* key, AtObj& data)
 
 void AtObj::set(const char* key, const wxString& value)
 {
-	set(key, value.wc_str());
+	set(key, static_cast<const wchar_t*>(value.wc_str()));
 }
 
 void AtObj::set(const char* key, const wchar_t* value)

--- a/source/tools/atlas/AtlasUI/CustomControls/MapDialog/MapDialog.cpp
+++ b/source/tools/atlas/AtlasUI/CustomControls/MapDialog/MapDialog.cpp
@@ -196,7 +196,7 @@ void MapDialog::SaveFile()
 		return;
 
 	// TODO: this test would work better outside the VFS
-	AtlasMessage::qVFSFileExists qry(filename.wc_str());
+	AtlasMessage::qVFSFileExists qry(static_cast<const wchar_t*>(filename.wc_str()));
 	qry.Post();
 	if (qry.exists)
 	{

--- a/source/tools/atlas/AtlasUI/CustomControls/MapDialog/MapDialog.cpp
+++ b/source/tools/atlas/AtlasUI/CustomControls/MapDialog/MapDialog.cpp
@@ -181,7 +181,7 @@ void MapDialog::OpenFile()
 	if (filename.empty())
 		return;
 
-	AtlasMessage::qVFSFileExists qry(filename.wc_str());
+	AtlasMessage::qVFSFileExists qry(static_cast<const wchar_t*>(filename.wc_str()));
 	qry.Post();
 	if (!qry.exists)
 		return;

--- a/source/tools/atlas/AtlasUI/ScenarioEditor/ScenarioEditor.cpp
+++ b/source/tools/atlas/AtlasUI/ScenarioEditor/ScenarioEditor.cpp
@@ -723,7 +723,7 @@ bool ScenarioEditor::OpenFile(const wxString& name, const wxString& filename)
 	wxBusyInfo busy(_("Loading ") + name);
 	wxBusyCursor busyc;
 
-	AtlasMessage::qVFSFileExists qry(filename.wc_str());
+	AtlasMessage::qVFSFileExists qry(static_cast<const wchar_t*>(filename.wc_str()));
 	qry.Post();
 	if (!qry.exists)
 		return false;


### PR DESCRIPTION
Compilation of Atlas failed on my system.
i386, GNU/Linux 4.9.62, gcc version 5.3.1
wxWidget version 3.1, compilation options here: http://sisyphus.ru/ru/srpm/Sisyphus/wxGTK3.1/spec . Maybe, problem in flags: -DUNICODE=1 -DwxUSE_UNICODE=1.
In patch forced cast wxString.wc_str() to "wchar_t". Its should work on all systems.