### PR TITLE
Fixed javascript error in singleplayer if game compiled --without-lobby

### DIFF
--- a/binaries/data/mods/public/gui/gamesetup/gamesetup.js
+++ b/binaries/data/mods/public/gui/gamesetup/gamesetup.js
@@ -242,7 +242,7 @@ var g_StunEndpoint;
 /**
  * Current username. Cannot contain whitespace.
  */
-var g_Username = Engine.LobbyGetNick();
+var g_Username = Engine.hasOwnProperty('LobbyGetNick') ? Engine.LobbyGetNick() : undefined;
 
 /**
  * States whether the GUI is currently updated in response to network messages instead of user input


### PR DESCRIPTION
Patch fixed:
ERROR: JavaScript error: gui/gamesetup/gamesetup.js line 240
TypeError: Engine.LobbyGetNick is not a function
  @gui/gamesetup/gamesetup.js:240:18
  __eventhandler11 (press)@__internal(12) press:0:1