### PR TITLE
Fix build with miniupnpc 2.2.8

### DIFF
--- a/binaries/data/mods/public/gui/credits/texts/programming.json
+++ b/binaries/data/mods/public/gui/credits/texts/programming.json
@@ -91,6 +91,7 @@
 				{ "nick": "edoput", "name": "Edoardo Putti"},
 				{ "nick": "eihrul", "name": "Lee Salzman" },
 				{ "nick": "elexis", "name": "Alexander Heinsius" },
+				{ "name": "Emily" },
 				{ "nick": "EmjeR", "name": "Matthijs de Rijk" },
 				{ "nick": "EMontana" },
 				{ "nick": "ericb" },


### PR DESCRIPTION
See <https://github.com/miniupnp/miniupnp/blob/miniupnpc_2_2_8/miniupnpc/Changelog.txt>.

Yes, they really decided to add a return code in the middle of their existing range, changing the semantics, in a release that bumped the version number by 0.0.1…

I saw that your main repository is still on Subversion and that there’s also a Gitea instance being tested. I wasn’t sure what the best way to contribute this patch back upstream would be, so I hope it’s okay to send a pull request here! Feel free to reroute this wherever it needs to go.